### PR TITLE
exit code fixed

### DIFF
--- a/src/here_fork_heredoc.c
+++ b/src/here_fork_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: haryu <haryu@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/12 16:43:02 by haryu             #+#    #+#             */
-/*   Updated: 2022/07/06 19:40:12 by haryu            ###   ########.fr       */
+/*   Updated: 2022/07/07 03:40:09 by haryu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,5 @@ void	fork_heredoc(t_flist **heredoc, int height, char *installed, int prev)
 	else
 		wait(&status);
 	g_global.last_exitcode = WEXITSTATUS(status);
-	if (WIFSIGNALED(status))
-		g_global.last_exitcode = 128 + WTERMSIG(status);
 	return ;
 }

--- a/src/here_handler_heredoc.c
+++ b/src/here_handler_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: haryu <haryu@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/18 12:08:21 by haryu             #+#    #+#             */
-/*   Updated: 2022/07/07 03:24:58 by haryu            ###   ########.fr       */
+/*   Updated: 2022/07/07 04:02:19 by haryu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,9 +14,5 @@
 
 void	handler_heredoc(int signum)
 {
-	if (signum == SIGQUIT)
-	{
-		return ;
-	}
 	exit(1);
 }

--- a/src/here_handler_heredoc.c
+++ b/src/here_handler_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: haryu <haryu@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/18 12:08:21 by haryu             #+#    #+#             */
-/*   Updated: 2022/07/01 04:45:20 by haryu            ###   ########.fr       */
+/*   Updated: 2022/07/07 03:24:58 by haryu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,5 +14,9 @@
 
 void	handler_heredoc(int signum)
 {
-	exit(128 + signum);
+	if (signum == SIGQUIT)
+	{
+		return ;
+	}
+	exit(1);
 }

--- a/src/here_heredoc_check.c
+++ b/src/here_heredoc_check.c
@@ -6,7 +6,7 @@
 /*   By: haryu <haryu@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/10 20:33:56 by haryu             #+#    #+#             */
-/*   Updated: 2022/07/06 19:38:38 by haryu            ###   ########.fr       */
+/*   Updated: 2022/07/07 03:45:07 by haryu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,7 +34,8 @@ int	heredoc_check(char *line, char *installed)
 		return (TRUE);
 	else
 	{
-		g_global.last_exitcode = prev_last;
+		if (prev_last != 0)
+			g_global.last_exitcode = prev_last;
 		return (FALSE);
 	}
 }

--- a/src/here_readline_heredoc.c
+++ b/src/here_readline_heredoc.c
@@ -6,39 +6,55 @@
 /*   By: haryu <haryu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/18 13:08:01 by haryu             #+#    #+#             */
-/*   Updated: 2022/07/05 18:56:26 by haryu            ###   ########.fr       */
+/*   Updated: 2022/07/07 03:54:20 by haryu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/minishell.h"
 
-static void	signal_heredoc(void)
+static void	heredoc_tcsetattr(struct termios *new)
+{
+	(*new) = g_global.old_settings;
+	new->c_lflag |= ICANON;
+	new->c_cc[VQUIT] = 255;
+	tcsetattr(0, TCSANOW, new);
+	return ;
+}
+
+static void	signal_heredoc(struct termios *new)
 {
 	signal(SIGINT, handler_heredoc);
-	signal(SIGQUIT, handler_heredoc);
+	heredoc_tcsetattr(new);
+	return ;
+}
+
+static void	check_len(char **line, int fd, int len)
+{
+	if (len == 0)
+		write(fd, "\n", 1);
+	free(*line);
 	return ;
 }
 
 int	readline_heredoc(int fd, int **cmd, t_flist **heredoc, int height)
 {
-	t_flist	*delimiter;
-	char	*line;
-	int		len;
+	t_flist			*delimiter;
+	struct termios	new;
+	char			*line;
+	int				len;
 
 	delimiter = find_delimiter(cmd, heredoc);
 	len = 0;
-	signal_heredoc();
+	signal_heredoc(&new);
 	while (TRUE)
 	{
 		line = readline("> ");
 		if (line == NULL)
-			exit(EXIT_FAILURE);
+			exit(0);
 		if (!ft_strncmp(line, delimiter->name, ft_strlen(delimiter->name)) && \
 ft_strlen(line) == ft_strlen(delimiter->name))
 		{
-			if (len == 0)
-				write(fd, "\n", 1);
-			free(line);
+			check_len(&line, fd, len);
 			break ;
 		}
 		putin_to_temp(line, &len, fd);

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: haryu <haryu@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/02 23:36:41 by haryu             #+#    #+#             */
-/*   Updated: 2022/07/06 18:41:31 by haryu            ###   ########.fr       */
+/*   Updated: 2022/07/07 02:57:09 by haryu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,7 +66,7 @@ int	main(void)
 		{
 			add_history_wrapper(&line);
 			back_tcsetattr(&new);
-			if (!pre_error_check(line))
+			if (ft_strlen(line) != 0 && !pre_error_check(line))
 			{
 				if (!heredoc_check(line, installed))
 					sentence_part(line);

--- a/src/pre_add_history_wrapper.c
+++ b/src/pre_add_history_wrapper.c
@@ -6,7 +6,7 @@
 /*   By: haryu <haryu@student.42seoul.kr>           +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/06 14:34:34 by haryu             #+#    #+#             */
-/*   Updated: 2022/07/06 14:38:31 by haryu            ###   ########.fr       */
+/*   Updated: 2022/07/07 02:54:33 by haryu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,10 @@
 void	add_history_wrapper(char **line)
 {
 	if (ft_strlen((*line)) == 0)
+	{
+		g_global.last_exitcode = 0;
 		return ;
+	}
 	else
 		add_history((*line));
 	return ;

--- a/src/sentence_ft_wait.c
+++ b/src/sentence_ft_wait.c
@@ -6,7 +6,7 @@
 /*   By: haryu <haryu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/06/18 11:37:27 by haryu             #+#    #+#             */
-/*   Updated: 2022/07/06 18:34:22 by haryu            ###   ########.fr       */
+/*   Updated: 2022/07/07 02:59:55 by haryu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,7 @@ int	ft_wait(pid_t *childs, int numbers, int builtin)
 		if (WIFSIGNALED(stats))
 			g_global.last_exitcode = 128 + WTERMSIG(stats);
 	}
-	if (prev != 0 && builtin == 1 && numbers == 1)
+	if (prev != 0 && builtin == 1 && numbers == 1 && !WIFSIGNALED(stat))
 		g_global.last_exitcode = prev;
 	free(childs);
 	if (g_global.last_exitcode != 0)


### PR DESCRIPTION
FIX : exit code about heredoc(signal quit -> 1, SIGQUIT disable)
ADD : new tcsetattr for heredoc (disable SIGQUIT).
FIX : SIGINT, SIGQUIT logic change in ft_wait(now highly get right exit code from childs)

배쉬와 동일하게 exit code 가 나올 수 있도록 heredoc 시그널 핸들러 수정, 배쉬에서 SIGQUIT ^\가 무시되는 것을 확인하였습니다. 이 역시 수정해서 무시하도록 만들었습니다. 
call cmd 이후 시그널로 종료시 간혈적으로 exit 값이 1이 되는 경우가 있었습니다. 
이는 exit 코드를 받는 조건(ft_wait)에서 하나가 빠져서 그런 것으로 확인되어, 해당 조건으로 수정해 주었습니다. 수십번 확인해본 결과 딱 한 번 cat 키고 ^C 를 눌렀을 때 1이 되었고 나머지는 정상적으로 시그널 값을 exit code 로 입력 되는 것을 확인하였습니다. 